### PR TITLE
Fix the old version resolved when using Gradle 8.2+

### DIFF
--- a/src/main/java/org/revapi/gradle/OldApiConfigurations.java
+++ b/src/main/java/org/revapi/gradle/OldApiConfigurations.java
@@ -36,14 +36,8 @@ final class OldApiConfigurations {
 
         Dependency oldApiDependency = project.getDependencies().create(groupNameVersion.asString());
 
-        String transitivityString = transitive ? "_transitive" : "";
-        String configurationName = "revapiOldApi_" + groupNameVersion.version().asString() + transitivityString;
-
-        Configuration oldApiConfiguration = project.getConfigurations().create(configurationName, conf -> {
-            conf.getDependencies().add(oldApiDependency);
-            conf.setCanBeConsumed(false);
-            conf.setVisible(false);
-        });
+        Configuration oldApiConfiguration = project.getConfigurations().detachedConfiguration();
+        oldApiConfiguration.getDependencies().add(oldApiDependency);
         oldApiConfiguration.setTransitive(transitive);
 
         return PreviousVersionResolutionHelpers.withRenamedGroupForCurrentThread(


### PR DESCRIPTION
## Before this PR
With Gradle 8.2+, the plugin doesn't detect any breaking change as it consider the same version for both old/new API.

## After this PR
The plugin cleanly detects breaking change with Gradle 8.2+.

## Possible downsides?
As it uses `externalConfigurations` the only downside could be the configuration caching is limited.

