### PR TITLE
Prepare for 1.8.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,8 @@ format:
 versionOverrides:
   group:name:version: versionOverride
 ```
+
+### Releasing a new version of the plugin
+
+The current release process is manual and is done via `./gradlew publishPlugins` while locally exporting the env variables `GRADLE_KEY` / `GRADLE_SECRET`.
+This will be updated shortly so that a new release can be triggered via a GitHub action.

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.gradle.plugin-publish' version '0.21.0'
+    id 'com.gradle.plugin-publish' version '1.2.1'
     id 'com.palantir.baseline' version '5.61.0'
     id 'com.palantir.consistent-versions' version '2.23.0'
     id 'com.palantir.git-version' version '3.1.0'
@@ -75,14 +75,14 @@ test {
 gradlePlugin {
     website = 'https://github.com/revapi/gradle-revapi'
     vcsUrl = 'https://github.com/revapi/gradle-revapi'
-    description = 'API/ABI backwards compatibility for Java libraries using Revapi'
 
     plugins {
         revapi {
             id = 'org.revapi.revapi-gradle-plugin'
             displayName = 'API/ABI backwards compatibility for Java libraries using Revapi'
+            description = 'API/ABI backwards compatibility for Java libraries using Revapi'
             implementationClass = 'org.revapi.gradle.RevapiPlugin'
-            tags.set(['versions'])
+            tags.set(['versions', 'api', 'abi'])
         }
     }
 }
@@ -92,9 +92,5 @@ tasks.named('processResources').configure {
 }
 
 tasks.publish.dependsOn tasks.publishPlugins
-publishPlugins.onlyIf {
-    versionDetails().isCleanTag
-}
 project.ext.'gradle.publish.key' = System.env["GRADLE_KEY"]
 project.ext.'gradle.publish.secret' = System.env["GRADLE_SECRET"]
-


### PR DESCRIPTION
This prepares the plugin for a 1.8.0 release. Note that the release is currently a manual step but will be automated in a future PR.