### PR TITLE
Add GH action for releasing plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+
+name: "Release new plugin version"
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'The version to release. The version format is MAJOR.MINOR.PATCH'
+        required: true
+
+jobs:
+  Release new plugin version:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ release_version }}
+      GRADLE_KEY: ${{ secrets.GRADLE_KEY }}
+      GRADLE_SECRET: ${{ secrets.GRADLE_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 11
+      - name: Publish plugin
+        run: ./gradlew publishPlugins

--- a/README.md
+++ b/README.md
@@ -117,5 +117,5 @@ versionOverrides:
 
 ### Releasing a new version of the plugin
 
-The current release process is manual and is done via `./gradlew publishPlugins` while locally exporting the env variables `GRADLE_KEY` / `GRADLE_SECRET`.
-This will be updated shortly so that a new release can be triggered via a GitHub action.
+A new version of the plugin can be released by manually triggering the `Release new plugin version` GH action.
+If necessary, a new version can also be manually released via `./gradlew publishPlugins` while locally exporting the env variables `GRADLE_KEY` / `GRADLE_SECRET`.

--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,7 @@ repositories {
 }
 
 group 'org.revapi'
-// TODO read the plugin from GH action
-// version System.env.CIRCLE_TAG ?: gitVersion()
-version '1.8.0'
+version System.env.RELEASE_VERSION ?: gitVersion()
 
 apply plugin: 'com.palantir.external-publish'
 apply plugin: 'java-gradle-plugin'


### PR DESCRIPTION
This adds a new GH action that allows to manually trigger and release a new version of the plugin