### PR TITLE
Apply JavaPlugin conditionally

### DIFF
--- a/src/main/java/org/revapi/gradle/RevapiPlugin.java
+++ b/src/main/java/org/revapi/gradle/RevapiPlugin.java
@@ -46,7 +46,12 @@ public final class RevapiPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().apply(LifecycleBasePlugin.class);
-        project.getPluginManager().apply(JavaPlugin.class);
+        if (!project.getPlugins().hasPlugin("java") &&
+            !project.getPlugins().hasPlugin("java-library") &&
+            !project.getPlugins().hasPlugin("com.android.library") &&
+            !project.getPlugins().hasPlugin("com.android.application")) {
+            project.getPluginManager().apply(JavaPlugin.class);
+        }
 
         RevapiExtension extension = project.getExtensions().create("revapi", RevapiExtension.class, project);
 


### PR DESCRIPTION
## Before this PR
The revapi-gradle-plugin unconditionally applies the org.gradle.api.plugins.JavaPlugin to any project it is applied to. This causes a conflict and build failure (e.g., "Cannot add task 'test' as a task with that name already exists") if another plugin that provides Java capabilities (like com.android.library, com.android.application, or even java-library itself) has already been applied to the project. This limits the plugin's applicability in common Gradle setups, especially for Android projects or multi-project builds where base Java functionality is established by other dedicated plugins.

## After this PR
The revapi-gradle-plugin will now conditionally apply the org.gradle.api.plugins.JavaPlugin. It first checks if the project already has a compatible Java plugin (java, java-library, com.android.library, com.android.application) applied. If such a plugin is detected, revapi-gradle-plugin will skip applying JavaPlugin itself, thus avoiding task registration conflicts.

## Possible downsides?
Not that I can think of since JavaPlugin will still be applied in other cases.
