### PR TITLE
Add Gradle 9 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ there was a covariant return type change to `docker-compose-rule` (`ImmutableDoc
 which [caused ABI breaks in `docker-proxy-rule`](https://github.com/palantir/docker-proxy-rule/releases/tag/0.8.0),
 among projects.
 
+## Gradle compatibility
+
+This plugin is compatible with **Gradle 8** and **Gradle 9**.
+
 ## Configuration
 
 `gradle-revapi` should work out of the box for most uses cases once applied. By default it compares against the previous

--- a/src/main/java/org/revapi/gradle/GitVersionUtils.java
+++ b/src/main/java/org/revapi/gradle/GitVersionUtils.java
@@ -25,30 +25,30 @@ import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.gradle.api.Project;
+import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecResult;
 import org.immutables.value.Value;
 
 final class GitVersionUtils {
     private GitVersionUtils() {}
 
-    public static Stream<String> previousGitTags(Project project) {
-        return StreamSupport.stream(new PreviousGitTags(project), false)
-                .filter(tag -> !isInitial000Tag(project, tag))
+    public static Stream<String> previousGitTags(ExecOperations execOperations) {
+        return StreamSupport.stream(new PreviousGitTags(execOperations), false)
+                .filter(tag -> !isInitial000Tag(execOperations, tag))
                 .map(GitVersionUtils::stripVFromTag);
     }
 
-    private static Optional<String> previousGitTagFromRef(Project project, String ref) {
+    private static Optional<String> previousGitTagFromRef(ExecOperations execOperations, String ref) {
         String beforeLastRef = ref + "^";
 
-        GitResult beforeLastRefTypeResult = execute(project, "git", "cat-file", "-t", beforeLastRef);
+        GitResult beforeLastRefTypeResult = execute(execOperations, "git", "cat-file", "-t", beforeLastRef);
 
         boolean thereIsNoCommitBeforeTheRef = !beforeLastRefTypeResult.stdout().equals("commit");
         if (thereIsNoCommitBeforeTheRef) {
             return Optional.empty();
         }
 
-        GitResult describeResult = execute(project, "git", "describe", "--tags", "--abbrev=0", beforeLastRef);
+        GitResult describeResult = execute(execOperations, "git", "describe", "--tags", "--abbrev=0", beforeLastRef);
 
         if (describeResult.stderr().contains("No tags can describe")
                 || describeResult.stderr().contains("No names found, cannot describe anything")) {
@@ -58,12 +58,12 @@ final class GitVersionUtils {
         return Optional.of(describeResult.stdoutOrThrowIfNonZero());
     }
 
-    private static boolean isInitial000Tag(Project project, String tag) {
+    private static boolean isInitial000Tag(ExecOperations execOperations, String tag) {
         if (!tag.equals("0.0.0")) {
             return false;
         }
 
-        GitResult foo = execute(project, "git", "rev-parse", "--verify", "--quiet", "0.0.0^");
+        GitResult foo = execute(execOperations, "git", "rev-parse", "--verify", "--quiet", "0.0.0^");
         boolean parentDoesNotExist = foo.exitCode() != 0;
         return parentDoesNotExist;
     }
@@ -76,11 +76,11 @@ final class GitVersionUtils {
         }
     }
 
-    private static GitResult execute(Project project, String... command) {
+    private static GitResult execute(ExecOperations execOperations, String... command) {
         ByteArrayOutputStream stdout = new ByteArrayOutputStream();
         ByteArrayOutputStream stderr = new ByteArrayOutputStream();
 
-        ExecResult execResult = project.exec(spec -> {
+        ExecResult execResult = execOperations.exec(spec -> {
             spec.setCommandLine(Arrays.asList(command));
             spec.setStandardOutput(stdout);
             spec.setErrorOutput(stderr);
@@ -124,16 +124,16 @@ final class GitVersionUtils {
     }
 
     private static final class PreviousGitTags implements Spliterator<String> {
-        private final Project project;
+        private final ExecOperations execOperations;
         private String lastSeenRef = "HEAD";
 
-        PreviousGitTags(Project project) {
-            this.project = project;
+        PreviousGitTags(ExecOperations execOperations) {
+            this.execOperations = execOperations;
         }
 
         @Override
         public boolean tryAdvance(Consumer<? super String> action) {
-            Optional<String> tag = previousGitTagFromRef(project, lastSeenRef);
+            Optional<String> tag = previousGitTagFromRef(execOperations, lastSeenRef);
 
             if (!tag.isPresent()) {
                 return false;

--- a/src/main/java/org/revapi/gradle/RevapiExtension.java
+++ b/src/main/java/org/revapi/gradle/RevapiExtension.java
@@ -22,6 +22,7 @@ import org.gradle.api.Project;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.process.ExecOperations;
 import org.revapi.gradle.config.GroupAndName;
 import org.revapi.gradle.config.GroupNameVersion;
 import org.revapi.gradle.config.Version;
@@ -34,6 +35,9 @@ public class RevapiExtension {
     private final Provider<GroupAndName> oldGroupAndName;
 
     public RevapiExtension(Project project) {
+        ExecOperations execOperations =
+                project.getObjects().newInstance(RevapiPlugin.ExecOpsHolder.class).getExecOperations();
+
         this.oldGroup = project.getObjects().property(String.class);
         this.oldGroup.set(
                 project.getProviders().provider(() -> project.getGroup().toString()));
@@ -43,8 +47,9 @@ public class RevapiExtension {
 
         this.oldVersions = project.getObjects().listProperty(String.class);
         this.oldVersions.set(project.getProviders()
-                .provider(
-                        () -> GitVersionUtils.previousGitTags(project).limit(3).collect(Collectors.toList())));
+                .provider(() -> GitVersionUtils.previousGitTags(execOperations)
+                        .limit(3)
+                        .collect(Collectors.toList())));
 
         this.oldGroupAndName = project.provider(() ->
                 GroupAndName.builder().group(oldGroup.get()).name(oldName.get()).build());

--- a/src/main/java/org/revapi/gradle/RevapiPlugin.java
+++ b/src/main/java/org/revapi/gradle/RevapiPlugin.java
@@ -20,10 +20,13 @@ import java.io.File;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ComponentResult;
 import org.gradle.api.attributes.Usage;
@@ -34,6 +37,8 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
+import org.gradle.process.ExecOperations;
+import org.gradle.util.GradleVersion;
 import org.revapi.gradle.ResolveOldApi.OldApi;
 import org.revapi.gradle.config.AcceptedBreak;
 import org.revapi.gradle.config.GroupAndName;
@@ -42,6 +47,15 @@ public final class RevapiPlugin implements Plugin<Project> {
     public static final String VERSION_OVERRIDE_TASK_NAME = "revapiVersionOverride";
     public static final String ACCEPT_BREAK_TASK_NAME = "revapiAcceptBreak";
     public static final String ACCEPT_ALL_BREAKS_TASK_NAME = "revapiAcceptAllBreaks";
+
+    private static final boolean GRADLE_9_OR_LATER =
+            GradleVersion.current().getBaseVersion().compareTo(GradleVersion.version("9.0")) >= 0;
+
+    /** Injectable helper to obtain {@link ExecOperations} from the Gradle service registry. */
+    public abstract static class ExecOpsHolder {
+        @Inject
+        public abstract ExecOperations getExecOperations();
+    }
 
     @Override
     public void apply(Project project) {
@@ -60,20 +74,18 @@ public final class RevapiPlugin implements Plugin<Project> {
                     // Creating a new configuration instead of using compileClasspath in order to ensure that we
                     // resolve jars and not classes directories (which is the default unless you set the LibraryElements
                     // attribute)
-                    Configuration revapiNewApi = project.getConfigurations().create("revapiNewApi", conf -> {
+                    Configuration revapiNewApi = createResolvableConfiguration(project, "revapiNewApi", conf -> {
                         conf.extendsFrom(
                                 project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
                         configureApiUsage(project, conf);
-                        conf.setCanBeConsumed(false);
                         conf.setVisible(false);
                     });
 
-                    Configuration revapiNewApiElements = project.getConfigurations()
-                            .create("revapiNewApiElements", conf -> {
+                    Configuration revapiNewApiElements =
+                            createResolvableConfiguration(project, "revapiNewApiElements", conf -> {
                                 conf.extendsFrom(project.getConfigurations()
                                         .getByName(JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME));
                                 configureApiUsage(project, conf);
-                                conf.setCanBeConsumed(false);
                                 conf.setVisible(false);
                             });
 
@@ -106,7 +118,8 @@ public final class RevapiPlugin implements Plugin<Project> {
                             .map(project::files)
                             .orElseGet(project::files)));
 
-                    task.getAnalysisResultsFile().set(new File(project.getBuildDir(), "revapi/revapi-results.json"));
+                    task.getAnalysisResultsFile()
+                            .set(project.getLayout().getBuildDirectory().file("revapi/revapi-results.json"));
 
                     task.onlyIf(oldApiIsPresent);
                 });
@@ -177,9 +190,29 @@ public final class RevapiPlugin implements Plugin<Project> {
         return new File(project.getRootDir(), ".palantir/revapi.yml");
     }
 
+    /**
+     * Creates a resolvable, non-consumable configuration compatible with both Gradle 8 and 9.
+     * In Gradle 9, {@code Configuration.setCanBeConsumed} is removed, so we use
+     * {@code ConfigurationContainer.resolvable} when available.
+     */
+    @SuppressWarnings("deprecation")
+    private static Configuration createResolvableConfiguration(
+            Project project, String name, Action<? super Configuration> configureAction) {
+        ConfigurationContainer configurations = project.getConfigurations();
+        if (GRADLE_9_OR_LATER) {
+            return configurations.resolvable(name, configureAction).get();
+        }
+        return configurations.create(name, conf -> {
+            conf.setCanBeConsumed(false);
+            configureAction.execute(conf);
+        });
+    }
+
     private File junitOutput(Project project) {
         Optional<String> circleReportsDir = Optional.ofNullable(System.getenv("CIRCLE_TEST_REPORTS"));
-        File reportsDir = circleReportsDir.map(File::new).orElseGet(project::getBuildDir);
+        File reportsDir = circleReportsDir
+                .map(File::new)
+                .orElseGet(() -> project.getLayout().getBuildDirectory().getAsFile().get());
         return new File(reportsDir, "junit-reports/revapi/revapi-" + project.getName() + ".xml");
     }
 }

--- a/src/test/groovy/org/revapi/gradle/GitVersionUtilsSpec.groovy
+++ b/src/test/groovy/org/revapi/gradle/GitVersionUtilsSpec.groovy
@@ -18,13 +18,16 @@ package org.revapi.gradle
 
 import java.util.stream.Collectors
 import nebula.test.AbstractProjectSpec
+import org.gradle.process.ExecOperations
 
 class GitVersionUtilsSpec extends AbstractProjectSpec {
     Git git
+    ExecOperations execOperations
 
     def setup() {
         git = new Git(ourProjectDir)
         git.initWithTestUser()
+        execOperations = project.objects.newInstance(RevapiPlugin.ExecOpsHolder).execOperations
     }
 
     def 'return nothing in a repo with no commits'() {
@@ -113,6 +116,6 @@ class GitVersionUtilsSpec extends AbstractProjectSpec {
     }
 
     private List<String> previousGitTags() {
-        GitVersionUtils.previousGitTags(getProject()).collect(Collectors.toList())
+        GitVersionUtils.previousGitTags(execOperations).collect(Collectors.toList())
     }
 }

--- a/src/test/java/org/revapi/gradle/IntegrationTest.java
+++ b/src/test/java/org/revapi/gradle/IntegrationTest.java
@@ -1,0 +1,148 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.revapi.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class IntegrationTest {
+
+    @TempDir
+    Path projectDir;
+
+    static Stream<String> gradleVersions() {
+        return Stream.of("8.7", "9.4.0");
+    }
+
+    @BeforeEach
+    void setup() throws IOException {
+        writeFile("settings.gradle", "rootProject.name = 'compat-test'\n");
+    }
+
+    @ParameterizedTest
+    @MethodSource("gradleVersions")
+    void pluginAppliesAndTasksAreRegistered(String gradleVersion) throws IOException {
+        writeFile(
+                "build.gradle",
+                "plugins {\n"
+                        + "    id 'org.revapi.revapi-gradle-plugin'\n"
+                        + "}\n"
+                        + "\n"
+                        + "repositories {\n"
+                        + "    mavenCentral()\n"
+                        + "}\n"
+                        + "\n"
+                        + "revapi {\n"
+                        + "    oldGroup = 'org.codehaus.cargo'\n"
+                        + "    oldName = 'empty-jar'\n"
+                        + "    oldVersion = '1.7.7'\n"
+                        + "}\n");
+
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withGradleVersion(gradleVersion)
+                .withPluginClasspath()
+                .withArguments("tasks", "--all", "--stacktrace")
+                .forwardOutput()
+                .build();
+
+        assertThat(result.getOutput()).contains("revapiAnalyze");
+        assertThat(result.getOutput()).contains("revapiAcceptBreak");
+        assertThat(result.getOutput()).contains("revapiAcceptAllBreaks");
+        assertThat(result.getOutput()).contains("revapiVersionOverride");
+    }
+
+    @ParameterizedTest
+    @MethodSource("gradleVersions")
+    void revapiTaskSucceedsWithNoBreakingChanges(String gradleVersion) throws IOException {
+        writeFile(
+                "build.gradle",
+                "plugins {\n"
+                        + "    id 'org.revapi.revapi-gradle-plugin'\n"
+                        + "}\n"
+                        + "\n"
+                        + "repositories {\n"
+                        + "    mavenCentral()\n"
+                        + "}\n"
+                        + "\n"
+                        + "revapi {\n"
+                        + "    oldGroup = 'org.codehaus.cargo'\n"
+                        + "    oldName = 'empty-jar'\n"
+                        + "    oldVersion = '1.7.7'\n"
+                        + "}\n");
+
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withGradleVersion(gradleVersion)
+                .withPluginClasspath()
+                .withArguments("revapi", "--stacktrace")
+                .forwardOutput()
+                .build();
+
+        assertThat(result.task(":revapiAnalyze").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":revapi").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+    }
+
+    @ParameterizedTest
+    @MethodSource("gradleVersions")
+    void revapiSkipsWhenOldVersionsIsEmpty(String gradleVersion) throws IOException {
+        writeFile(
+                "build.gradle",
+                "plugins {\n"
+                        + "    id 'org.revapi.revapi-gradle-plugin'\n"
+                        + "}\n"
+                        + "\n"
+                        + "repositories {\n"
+                        + "    mavenCentral()\n"
+                        + "}\n"
+                        + "\n"
+                        + "revapi {\n"
+                        + "    oldGroup = 'org.revapi'\n"
+                        + "    oldName = 'revapi'\n"
+                        + "    oldVersions = []\n"
+                        + "}\n");
+
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withGradleVersion(gradleVersion)
+                .withPluginClasspath()
+                .withArguments("revapi", "--stacktrace")
+                .forwardOutput()
+                .build();
+
+        assertThat(result.task(":revapiAnalyze").getOutcome()).isEqualTo(TaskOutcome.SKIPPED);
+        assertThat(result.task(":revapi").getOutcome()).isEqualTo(TaskOutcome.SKIPPED);
+    }
+
+    private void writeFile(String relativePath, String content) throws IOException {
+        Path file = projectDir.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.write(file, content.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Context

I want to use the Revapi plugin with Gradle 8 and Gradle 9

## Summary
- Replace deprecated/removed Gradle APIs (`project.getBuildDir()`, `project.exec()`, `Configuration.setCanBeConsumed()`) with Gradle 9 compatible alternatives
- Add version-aware configuration creation that uses `configurations.resolvable()` on Gradle 9+ and falls back to `configurations.create()` on Gradle 8
- Use injected `ExecOperations` instead of `Project.exec()` for running git commands
- Add `IntegrationTest` using JUnit 5 `@ParameterizedTest` and `GradleRunner` to validate against Gradle 8.7 and 9.4.0
- Update README with Gradle compatibility section

## Test plan
- [x] All existing tests pass (51 tests)
- [x] New `IntegrationTest` passes for both Gradle 8.7 and 9.4.0 (6 tests)
- [x] Verify plugin works in a real project with Gradle 8
- [x] Verify plugin works in a real project with Gradle 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)